### PR TITLE
Dev/alvaro

### DIFF
--- a/workflow.sh
+++ b/workflow.sh
@@ -60,6 +60,11 @@ echod() {
 # Convert command line inputs to environment variables.
 f_read_cmd_args $@
 
+# Get workflow host:
+WFP_whost=$(cat pw.conf | grep sites | grep -o -P '(?<=\[).*?(?=\])').clusters.pw
+# Expand into user@ip (not necessary in this case but makes workflow faster)
+WFP_whost=$(${CONDA_PYTHON_EXE} /swift-pw-bin/utils/cluster-ip-api-wrapper.py ${WFP_whost})
+
 # List of input arguments converted to environment vars:
 env | grep WFP_
 

--- a/workflow.sh
+++ b/workflow.sh
@@ -101,6 +101,9 @@ echo "submitting batch job..."
 jobid=$(${sshcmd} "sbatch -N ${WFP_nnodes} --ntasks-per-node=${WFP_ppn} ${WFP_jobscript};echo Runcmd done2 >> ~/job.exit" | tail -1 | awk -F ' ' '{print $4}')
 echo "JOB ID: ${jobid}"
 
+# Prepare kill script
+echo "${sshcmd} \"scancel ${jobid}\"" > kill.sh
+
 # Job status file writen by remote script:
 while true; do    
     # squeue won't give you status of jobs that are not running or waiting to run

--- a/workflow.sh
+++ b/workflow.sh
@@ -70,7 +70,7 @@ env | grep WFP_
 
 # Testing echod
 echod Testing echod. Currently on `hostname`.
-echod Will excute as $PW_USER@$WFP_whost
+echod Will excute as $WFP_whost
 
 #===============================
 # Run things

--- a/workflow.xml
+++ b/workflow.xml
@@ -2,13 +2,6 @@
   <command interpreter='bash'>workflow.sh</command>
   <inputs>
     <section name='commands' type='section' conditional='[object Object],[object Object]' title='Commands' expanded='true'>
-      <param name='wuser'
-             label='User name'
-             type='text'
-             value='__USER__'
-             help='Username for account on the Workflow Host. Your PW account username will automatically substitute __USER__; other values will be treated as typed.'
-             width='50%_none'>
-      </param>
       <param name='nnodes'
              label='Number of nodes'
              type='text'

--- a/workflow.xml
+++ b/workflow.xml
@@ -9,13 +9,6 @@
              help='Username for account on the Workflow Host. Your PW account username will automatically substitute __USER__; other values will be treated as typed.'
              width='50%_none'>
       </param>
-      <param name='whost'
-             label='Workflow host'
-             type='text'
-             value='cloud.clusters.pw'
-             help='Use PoolName.clusters.pw for cloud clusters or user@host_ip otherwise'
-             width='50%_none'>
-      </param>
       <param name='nnodes'
              label='Number of nodes'
              type='text'


### PR DESCRIPTION
Made following changes to the workflow while trying to keep most of the code intact:

Obtain remote host from pw.conf file
Prevent workflow from exiting unless SLURM job is not running. This is mostly required to monitor the job from PW and specially to be able to cancel it with kill.sh
Added kill.sh creation
Define sshcmd command
Added SLURM job status monitoring
Remove references to USER or PW_USER since they are not needed